### PR TITLE
feat(dropdown): add dropdown and dropdown-menu directives

### DIFF
--- a/src/dropdown/test/dropdown.spec.js
+++ b/src/dropdown/test/dropdown.spec.js
@@ -7,7 +7,70 @@ describe('dropdown', function() {
     $controller = _$controller_;
     $document = _$document_;
     $scope = _$rootScope_;
-    $scope.data = {};
     $timeout = _$timeout_;
   }));
+  afterEach(function() {
+    $element = undefined;
+  });
+
+  it('should show on click', function() {
+    $element = $compile('<div><div dropdown><div dropdown-menu></div></div></div>')($scope);
+    $scope.$digest();
+    var $dropdown = $element.children().eq(0),
+        ctrl = $dropdown.controller('dropdown');
+    spyOn(ctrl, 'show').andCallThrough();
+    $dropdown.trigger('click');
+    expect(ctrl.show).toHaveBeenCalled();
+  });
+
+
+  it('should hide on document click', function() {
+    var i = 0;
+    $element = $compile('<div><div dropdown><div dropdown-menu></div></div></div>')($scope);
+    $scope.$digest();
+    var $dropdown = $element.children().eq(0),
+        ctrl = $dropdown.controller('dropdown');
+    ctrl.show();
+    spyOn(ctrl, 'hide').andCallThrough();
+    waitsFor(function() { return i++ === 1; });
+    runs(function() {
+      ctrl._document.trigger('click');
+      expect(ctrl.hide).toHaveBeenCalled();
+    });
+  });
+
+
+  it('should hide on self click', function() {
+    var i = 0;
+    $element = $compile('<div><div dropdown><div dropdown-menu></div></div></div>')($scope);
+    $scope.$digest();
+    var $dropdown = $element.children().eq(0),
+        ctrl = $dropdown.controller('dropdown');
+    ctrl.show();
+    spyOn(ctrl, 'hide').andCallThrough();
+    waitsFor(function() { return i++ === 1; });
+    runs(function() {
+      $dropdown.trigger('click');
+      expect(ctrl.hide).toHaveBeenCalled();
+    });
+  });
+
+  it('should hide other dropdowns when opening', function() {
+    $element = $compile('<div><div dropdown><div dropdown-menu></div></div>' +
+                             '<div dropdown><div dropdown-menu></div></div></div>')($scope);
+    $scope.$digest();
+    var $dropdown1 = $element.children().eq(0),
+        $dropdown2 = $element.children().eq(1),
+        ctrl1 = $dropdown1.controller('dropdown'),
+        ctrl2 = $dropdown2.controller('dropdown');
+    spyOn(ctrl1, 'hide').andCallThrough();
+    spyOn(ctrl2, 'hide').andCallThrough();
+    ctrl1.show();
+    ctrl1.hide.reset();
+    ctrl2.show();
+    expect(ctrl1.hide).toHaveBeenCalled();
+    ctrl2.hide.reset();
+    ctrl1.show();
+    expect(ctrl2.hide).toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Initial work on some AngularJS ports of the dropdown modules.

As of yet, there is no real test suite, and testing has only been happening in what I intend to be a future demo site for the AngularSemantic codebase.

Currently, transition support is experimental, using $animate's addClass methods exclusively. I'd like to make this a bit more dynamic, and additionally support jQuery animation functions if jQuery is detected -- But for now, this is working nicely, I think.
