### PR TITLE
chore(travis): use Node.js v0.10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - 0.8
+  - 0.10
 
 before_script:
   - export DISPLAY=:99.0


### PR DESCRIPTION
load-grunt-tasks v0.4.0 doesn't like Node 0.8
