### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-##AngularSemantic [![Build Status](https://travis-ci.org/caitp/angular-semantic.svg?branch=master)](https://travis-ci.org/caitp/angular-semantic) [![devDependency Status](https://david-dm.org/caitp/angular-semantic/dev-status.svg?branch=master)](https://david-dm.org/caitp/angular-semantic#info=devDependencies)
+## AngularSemantic [![Build Status](https://travis-ci.org/caitp/angular-semantic.svg?branch=master)](https://travis-ci.org/caitp/angular-semantic) [![devDependency Status](https://david-dm.org/caitp/angular-semantic/dev-status.svg?branch=master)](https://david-dm.org/caitp/angular-semantic#info=devDependencies)
 
 [Docs](http://caitp.github.io/angular-semantic/docs)
 
 Work-in-progress on [AngularJS](http://angularjs.org) directives to support [Semantic-UI](http://semantic-ui.com) modules.
 
-###About
+### About
 
 This is in extremely early stages currently, and will likely not get very far without your help!
 
@@ -12,21 +12,21 @@ Please, fork, pick a module, implement it and provide as many thoroughly rigid (
 
 Let us work together to turn Semantic-UI into a truely semantic framework with AngularJS directives bringing the markup to life.
 
-###Dependencies
+### Dependencies
 - Semantic-UI
 - AngularJS
 
-###Global DevDependencies
+### Global DevDependencies
 - grunt-cli
 
-###Building
+### Building
 
 ```bash
 $ npm install --dev
 $ grunt
 ```
 
-###Testing
+### Testing
 
 Testing locally, by default, uses the Chrome browser. However, it is necessary to install the Karma Chrome launcher before making use of it.
 To do this, run `grunt setup --launchers chrome` to install it, as a convenience. You can also install other launchers this way, such as
@@ -35,7 +35,7 @@ To do this, run `grunt setup --launchers chrome` to install it, as a convenience
 To run tests, simply run `grunt test`. Currently, testing with alternative browsers requires either changes to the Gruntfile, or else changes
 to karma.conf.js. This will be improved in the near future.
 
-###Contribution
+### Contribution
 
 Any form of contribution is welcome, whether it be a bug report, a feature request, a feature implementation, a bug fix, or even an example usage or additional test. The contribution is welcome and appreciated.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
